### PR TITLE
Add OpenAFS server classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,46 @@
 [![pdk-validate](https://github.com/ncsa/puppet-openafs/actions/workflows/pdk-validate.yml/badge.svg)](https://github.com/ncsa/puppet-openafs/actions/workflows/pdk-validate.yml)
 [![yamllint](https://github.com/ncsa/puppet-openafs/actions/workflows/yamllint.yml/badge.svg)](https://github.com/ncsa/puppet-openafs/actions/workflows/yamllint.yml)
 
-Puppet module to install and configure the OpenAFS client
+Puppet module to install and configure OpenAFS
+
+OpenAFS is a distributed filesystem: https://www.openafs.org/
+
+## Usage
+
+To install and configure the **OpenAFS client**:
+
+```
+  include openafs::client
+```
+
+To install and configure the **OpenAFS database server**:
+
+```
+  include openafs::database_server
+```
+
+To install and configure the **OpenAFS file server**:
+
+```
+  include openafs::file_server
+```
+
+## Configuration
+
+The following parameters need to be set:
+- `openafs::cellalias`: String of your OpenAFS CellAlias content
+- `openafs::thiscell`: String of your OpenAFS ThisCell content
+- `openafs::server::cellservdb`: String of your OpenAFS CellServDB content
+- `openafs::server::keyfile_base64`: String of your base64 encoded KeyFile content
+- `openafs::server::keyfileext_base64`: String of your base64 encoded KeyFileExt content
+- `openafs::server::krb_conf`: String of your OpenAFS krb.conf content (Kerberos realm name)
+- `openafs::server::license`: String of your OpenAFS License content
+- `openafs::server::rxkad_keytab_base64`: String of your base64 encoded rxkad.keytab content
 
 ## Dependencies
 - [puppet/epel](https://forge.puppet.com/puppet/epel)
 - [puppetlabs/firewall](https://forge.puppet.com/puppetlabs/firewall)
+- [puppetlabs/stdlib](https://forge.puppet.com/modules/puppetlabs/stdlib)
 
 ## Reference
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6,21 +6,30 @@
 
 ### Classes
 
-* [`openafs`](#openafs): A short summary of the purpose of this class
-* [`openafs::client`](#openafsclient): A short summary of the purpose of this class
-* [`openafs::client::firewall`](#openafsclientfirewall): A short summary of the purpose of this class
-* [`openafs::client::packages`](#openafsclientpackages): A short summary of the purpose of this class
-* [`openafs::client::rebuild`](#openafsclientrebuild): A short summary of the purpose of this class
-* [`openafs::client::service`](#openafsclientservice): A short summary of the purpose of this class
-* [`openafs::common`](#openafscommon): A short summary of the purpose of this class
-* [`openafs::server::database`](#openafsserverdatabase): A short summary of the purpose of this class
-* [`openafs::server::file`](#openafsserverfile): A short summary of the purpose of this class
+* [`openafs`](#openafs): Install and configure OpenAFS packages and services
+* [`openafs::client`](#openafsclient): Install and configure OpenAFS client
+* [`openafs::client::firewall`](#openafsclientfirewall): Configure the firewall settings for OpenAFS client
+* [`openafs::client::packages`](#openafsclientpackages): Install packages for OpenAFS client
+* [`openafs::client::rebuild`](#openafsclientrebuild): Rebuild the kernel module for OpenAFS when needed
+* [`openafs::client::service`](#openafsclientservice): Configure service for OpenAFS client
+* [`openafs::common`](#openafscommon): Configure settings common to all OpenAFS services
+* [`openafs::database_server`](#openafsdatabase_server): Install and configure OpenAFS database server
+* [`openafs::database_server::firewall`](#openafsdatabase_serverfirewall): Configure the firewall settings for OpenAFS database server
+* [`openafs::database_server::packages`](#openafsdatabase_serverpackages): Install packages for OpenAFS database server
+* [`openafs::database_server::service`](#openafsdatabase_serverservice): Configure service for OpenAFS database server
+* [`openafs::file_server`](#openafsfile_server): Install and configure OpenAFS file server
+* [`openafs::file_server::firewall`](#openafsfile_serverfirewall): Configure the firewall settings for OpenAFS file server
+* [`openafs::file_server::packages`](#openafsfile_serverpackages): Install packages for OpenAFS file server
+* [`openafs::file_server::rebuild`](#openafsfile_serverrebuild): Rebuild the kernel module for OpenAFS when needed
+* [`openafs::file_server::service`](#openafsfile_serverservice): Configure service for OpenAFS file server
+* [`openafs::server_common`](#openafsserver_common): Configure common settings to all OpenAFS server types
+* [`openafs::yumrepo`](#openafsyumrepo): Install and configure OpenAFS YUM repository
 
 ## Classes
 
 ### <a name="openafs"></a>`openafs`
 
-A description of what this class does
+Install and configure OpenAFS packages and services
 
 #### Examples
 
@@ -32,7 +41,7 @@ include openafs
 
 ### <a name="openafsclient"></a>`openafs::client`
 
-A description of what this class does
+Install and configure OpenAFS client
 
 #### Examples
 
@@ -42,9 +51,21 @@ A description of what this class does
 include openafs::client
 ```
 
+#### Parameters
+
+The following parameters are available in the `openafs::client` class:
+
+* [`profile_files`](#profile_files)
+
+##### <a name="profile_files"></a>`profile_files`
+
+Data type: `Hash`
+
+Hash of profile files related to OpenAFS client usage
+
 ### <a name="openafsclientfirewall"></a>`openafs::client::firewall`
 
-A description of what this class does
+Configure the firewall settings for OpenAFS client
 
 #### Examples
 
@@ -58,31 +79,31 @@ include openafs::client::firewall
 
 The following parameters are available in the `openafs::client::firewall` class:
 
-* [`dport`](#dport)
+* [`dports`](#dports)
 * [`proto`](#proto)
-* [`source`](#source)
+* [`sources`](#sources)
 
-##### <a name="dport"></a>`dport`
+##### <a name="dports"></a>`dports`
 
-Data type: `String`
+Data type: `Array[String]`
 
-
+Array of destination ports that need to be open for the OpenAFS client
 
 ##### <a name="proto"></a>`proto`
 
 Data type: `String`
 
+String of protocol that needs to be open for the OpenAFS client
 
+##### <a name="sources"></a>`sources`
 
-##### <a name="source"></a>`source`
+Data type: `Array[String]`
 
-Data type: `String`
-
-
+Array CIDR sources that need to be open for the OpenAFS client
 
 ### <a name="openafsclientpackages"></a>`openafs::client::packages`
 
-A description of what this class does
+Install packages for OpenAFS client
 
 #### Examples
 
@@ -96,24 +117,24 @@ include openafs::client::packages
 
 The following parameters are available in the `openafs::client::packages` class:
 
-* [`prereq_packages`](#prereq_packages)
 * [`packages`](#packages)
-
-##### <a name="prereq_packages"></a>`prereq_packages`
-
-Data type: `Array`
-
-
+* [`prereq_packages`](#prereq_packages)
 
 ##### <a name="packages"></a>`packages`
 
 Data type: `Array`
 
+Array of packages that need to be installed for the OpenAFS client
 
+##### <a name="prereq_packages"></a>`prereq_packages`
+
+Data type: `Array`
+
+Array of prerequisite packages that need to be installed for the OpenAFS client
 
 ### <a name="openafsclientrebuild"></a>`openafs::client::rebuild`
 
-A description of what this class does
+Rebuild the kernel module for OpenAFS when needed
 
 #### Examples
 
@@ -125,7 +146,7 @@ include openafs::client::rebuild
 
 ### <a name="openafsclientservice"></a>`openafs::client::service`
 
-A description of what this class does
+Configure service for OpenAFS client
 
 #### Examples
 
@@ -147,23 +168,23 @@ The following parameters are available in the `openafs::client::service` class:
 
 Data type: `Boolean`
 
-
+Boolean of whether the default service should be enabled
 
 ##### <a name="ensure"></a>`ensure`
 
 Data type: `String`
 
-
+String of how the default service should be ensured
 
 ##### <a name="service_name"></a>`service_name`
 
 Data type: `String`
 
-
+String of the name of the default service
 
 ### <a name="openafscommon"></a>`openafs::common`
 
-A description of what this class does
+Configure settings common to all OpenAFS services
 
 #### Examples
 
@@ -173,60 +194,294 @@ A description of what this class does
 include openafs::common
 ```
 
+### <a name="openafsdatabase_server"></a>`openafs::database_server`
+
+Install and configure OpenAFS database server
+
+#### Examples
+
+##### 
+
+```puppet
+include openafs::database_server
+```
+
+### <a name="openafsdatabase_serverfirewall"></a>`openafs::database_server::firewall`
+
+Configure the firewall settings for OpenAFS database server
+
+#### Examples
+
+##### 
+
+```puppet
+include openafs::database_server::firewall
+```
+
 #### Parameters
 
-The following parameters are available in the `openafs::common` class:
+The following parameters are available in the `openafs::database_server::firewall` class:
 
-* [`cellalias`](#cellalias)
-* [`profile_files`](#profile_files)
-* [`thiscell`](#thiscell)
-* [`yumrepo`](#yumrepo)
+* [`dports`](#dports)
+* [`proto`](#proto)
+* [`sources`](#sources)
 
-##### <a name="cellalias"></a>`cellalias`
+##### <a name="dports"></a>`dports`
+
+Data type: `Array[String]`
+
+Array of destination ports that need to be open for the OpenAFS database server
+
+##### <a name="proto"></a>`proto`
 
 Data type: `String`
 
+String of protocol that needs to be open for the OpenAFS database server
 
+##### <a name="sources"></a>`sources`
 
-##### <a name="profile_files"></a>`profile_files`
+Data type: `Array[String]`
+
+Array CIDR sources that need to be open for the OpenAFS database server
+
+### <a name="openafsdatabase_serverpackages"></a>`openafs::database_server::packages`
+
+Install packages for OpenAFS database server
+
+#### Examples
+
+##### 
+
+```puppet
+include openafs::database_server::packages
+```
+
+#### Parameters
+
+The following parameters are available in the `openafs::database_server::packages` class:
+
+* [`packages`](#packages)
+
+##### <a name="packages"></a>`packages`
+
+Data type: `Array`
+
+Array of packages that need to be installed for the OpenAFS database server
+
+### <a name="openafsdatabase_serverservice"></a>`openafs::database_server::service`
+
+Configure service for OpenAFS database server
+
+#### Examples
+
+##### 
+
+```puppet
+include openafs::database_server::service
+```
+
+#### Parameters
+
+The following parameters are available in the `openafs::database_server::service` class:
+
+* [`enable`](#enable)
+* [`ensure`](#ensure)
+* [`service_name`](#service_name)
+
+##### <a name="enable"></a>`enable`
+
+Data type: `Boolean`
+
+Boolean of whether the default service should be enabled
+
+##### <a name="ensure"></a>`ensure`
+
+Data type: `String`
+
+String of how the default service should be ensured
+
+##### <a name="service_name"></a>`service_name`
+
+Data type: `String`
+
+String of the name of the default service
+
+### <a name="openafsfile_server"></a>`openafs::file_server`
+
+Install and configure OpenAFS file server
+
+#### Examples
+
+##### 
+
+```puppet
+include openafs::file_server
+```
+
+### <a name="openafsfile_serverfirewall"></a>`openafs::file_server::firewall`
+
+Configure the firewall settings for OpenAFS file server
+
+#### Examples
+
+##### 
+
+```puppet
+include openafs::file_server::firewall
+```
+
+#### Parameters
+
+The following parameters are available in the `openafs::file_server::firewall` class:
+
+* [`dports`](#dports)
+* [`proto`](#proto)
+* [`sources`](#sources)
+
+##### <a name="dports"></a>`dports`
+
+Data type: `Array[String]`
+
+Array of destination ports that need to be open for the OpenAFS file server
+
+##### <a name="proto"></a>`proto`
+
+Data type: `String`
+
+String of protocol that needs to be open for the OpenAFS file server
+
+##### <a name="sources"></a>`sources`
+
+Data type: `Array[String]`
+
+Array CIDR sources that need to be open for the OpenAFS file server
+
+### <a name="openafsfile_serverpackages"></a>`openafs::file_server::packages`
+
+Install packages for OpenAFS file server
+
+#### Examples
+
+##### 
+
+```puppet
+include openafs::file_server::packages
+```
+
+#### Parameters
+
+The following parameters are available in the `openafs::file_server::packages` class:
+
+* [`packages`](#packages)
+* [`prereq_packages`](#prereq_packages)
+
+##### <a name="packages"></a>`packages`
+
+Data type: `Array`
+
+Array of packages that need to be installed for the OpenAFS file server
+
+##### <a name="prereq_packages"></a>`prereq_packages`
+
+Data type: `Array`
+
+Array of prerequisite packages that need to be installed for the OpenAFS file server
+
+### <a name="openafsfile_serverrebuild"></a>`openafs::file_server::rebuild`
+
+Rebuild the kernel module for OpenAFS when needed
+
+#### Examples
+
+##### 
+
+```puppet
+include openafs::file_server::rebuild
+```
+
+### <a name="openafsfile_serverservice"></a>`openafs::file_server::service`
+
+Configure service for OpenAFS file server
+
+#### Examples
+
+##### 
+
+```puppet
+include openafs::file_server::service
+```
+
+#### Parameters
+
+The following parameters are available in the `openafs::file_server::service` class:
+
+* [`enable`](#enable)
+* [`ensure`](#ensure)
+* [`service_name`](#service_name)
+
+##### <a name="enable"></a>`enable`
+
+Data type: `Boolean`
+
+Boolean of whether the default service should be enabled
+
+##### <a name="ensure"></a>`ensure`
+
+Data type: `String`
+
+String of how the default service should be ensured
+
+##### <a name="service_name"></a>`service_name`
+
+Data type: `String`
+
+String of the name of the default service
+
+### <a name="openafsserver_common"></a>`openafs::server_common`
+
+Configure common settings to all OpenAFS server types
+
+#### Examples
+
+##### 
+
+```puppet
+include openafs::server_common
+```
+
+#### Parameters
+
+The following parameters are available in the `openafs::server_common` class:
+
+* [`files`](#files)
+
+##### <a name="files"></a>`files`
 
 Data type: `Hash`
 
+Hash of common server config files for OpenAFS servers
 
+### <a name="openafsyumrepo"></a>`openafs::yumrepo`
 
-##### <a name="thiscell"></a>`thiscell`
+Install and configure OpenAFS YUM repository
 
-Data type: `String`
+#### Examples
 
+##### 
 
+```puppet
+include openafs::yumrepo
+```
+
+#### Parameters
+
+The following parameters are available in the `openafs::yumrepo` class:
+
+* [`yumrepo`](#yumrepo)
 
 ##### <a name="yumrepo"></a>`yumrepo`
 
 Data type: `Hash`
 
-
-
-### <a name="openafsserverdatabase"></a>`openafs::server::database`
-
-A description of what this class does
-
-#### Examples
-
-##### 
-
-```puppet
-include openafs::server::database
-```
-
-### <a name="openafsserverfile"></a>`openafs::server::file`
-
-A description of what this class does
-
-#### Examples
-
-##### 
-
-```puppet
-include openafs::server::file
-```
+Hash of yumrepo parameters for OpenAFS YUM repository
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,6 +1,62 @@
 ---
-openafs::client::firewall::dport: "7000-7009"
+lookup_options:
+  openafs::server_common::files:
+    merge:
+      strategy: "deep"
+      merge_hash_arrays: true
+
+openafs::client::firewall::dports:
+  - "7001"
 openafs::client::firewall::proto: "udp"
-openafs::client::firewall::source: "141.142.0.0/16"
-openafs::common::cellalias: "ncsa.uiuc.edu ncsa"
-openafs::common::thiscell: "ncsa.uiuc.edu"
+openafs::client::firewall::sources:
+  - "0.0.0.0/0"
+
+openafs::cellalias: |
+  changeme.local changeme
+openafs::thiscell: "changeme.local"
+openafs::server::cellservdb: {}
+openafs::server::keyfile_base64: {}
+openafs::server::keyfileext_base64: {}
+openafs::server::krb_conf: "CHANGEME.LOCAL"
+openafs::server::license: {}
+openafs::server::rxkad_keytab_base64: {}
+openafs::server::userlist: |
+  admin
+  backup
+  vdvadmin
+  adminl
+
+openafs::database_server::firewall::dports:
+  - "7002"
+  - "7003"
+  - "7007"
+  - "7008"
+openafs::database_server::firewall::proto: "udp"
+openafs::database_server::firewall::sources:
+  - "0.0.0.0/0"
+
+openafs::file_server::firewall::dports:
+  - "7000"
+  - "7005"
+  - "7007"
+  - "7008"
+openafs::file_server::firewall::proto: "udp"
+openafs::file_server::firewall::sources:
+  - "0.0.0.0/0"
+
+openafs::server_common::files:
+  /var/openafs:
+    ensure: "directory"
+    mode: "0700"
+  /var/openafs/backup:
+    ensure: "directory"
+    mode: "0700"
+  /var/openafs/backup/logs:
+    ensure: "directory"
+    mode: "0755"
+  /var/openafs/local:
+    ensure: "directory"
+    mode: "0750"
+  /var/openafs/logs:
+    ensure: "directory"
+    mode: "0755"

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -8,10 +8,7 @@ openafs::client::packages::packages:
   - "openafs-client"
   - "openafs-docs"
   - "openafs-krb5"
-openafs::client::service::enable: true
-openafs::client::service::ensure: "running"
-openafs::client::service::service_name: "openafs-client"
-openafs::common::profile_files:
+openafs::client::profile_files:
   /etc/profile.d/00-openafs.csh: |
     # This file is managed by Puppet.
     # ONLY RUN FOR NORMAL USERS
@@ -51,13 +48,46 @@ openafs::common::profile_files:
         fi
       fi
     fi
+openafs::client::service::enable: true
+openafs::client::service::ensure: "running"
+openafs::client::service::service_name: "openafs-client"
+
+#openafs::database_server::packages::prereq_packages: {}
+#  - "dkms"
+#  - "kernel-devel"
+openafs::database_server::packages::packages:
+#  - "dkms-openafs"
+  - "openafs"
+  - "openafs-docs"
+  - "openafs-krb5"
+  - "openafs-server"
+#  - "openafs-transarc-server"
+openafs::database_server::service::enable: true
+openafs::database_server::service::ensure: "running"
+openafs::database_server::service::service_name: "openafs-server"
+
+openafs::file_server::packages::prereq_packages:
+  - "dkms"
+  - "kernel-devel"
+openafs::file_server::packages::packages:
+  - "dkms-openafs"
+  - "openafs"
+  - "openafs-client"
+  - "openafs-docs"
+  - "openafs-krb5"
+  - "openafs-server"
+#  - "openafs-transarc-server"
+openafs::file_server::service::enable: true
+openafs::file_server::service::ensure: "running"
+openafs::file_server::service::service_name: "openafs-server"
+
 openafs::yumrepo::yumrepo:
   openafs:
     descr: "openafs"
     ensure: "present"
     enabled: true
-    baseurl: "https://its-repo.ncsa.illinois.edu/openafs/jsbillings/centos-$releasever-$basearch/latest/"
+    baseurl: "https://copr-be.cloud.fedoraproject.org/results/jsbillings/openafs/epel-$releasever-$basearch/"
     skip_if_unavailable: true
     gpgcheck: true
-    gpgkey: "https://its-repo.ncsa.illinois.edu/openafs/jsbillings/centos-$releasever-$basearch/pubkey.gpg"
+    gpgkey: "https://copr-be.cloud.fedoraproject.org/results/jsbillings/openafs/pubkey.gpg"
     repo_gpgcheck: false

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,10 +1,13 @@
-# @summary A short summary of the purpose of this class
+# @summary Install and configure OpenAFS client
 #
-# A description of what this class does
+# @param profile_files
+#   Hash of profile files related to OpenAFS client usage
 #
 # @example
 #   include openafs::client
-class openafs::client {
+class openafs::client (
+  Hash   $profile_files,
+) {
 
   include epel
   include openafs::common
@@ -20,5 +23,11 @@ class openafs::client {
         -> Class['openafs::common']
           -> Class['openafs::client::rebuild']
             -> Class['openafs::client::service']
+
+  $profile_files.each | $filename, $content | {
+    file { $filename:
+      content => $content,
+    }
+  }
 
 }

--- a/manifests/client/firewall.pp
+++ b/manifests/client/firewall.pp
@@ -1,21 +1,30 @@
-# @summary A short summary of the purpose of this class
+# @summary Configure the firewall settings for OpenAFS client
 #
-# A description of what this class does
+# @param dports
+#   Array of destination ports that need to be open for the OpenAFS client
+#
+# @param proto
+#   String of protocol that needs to be open for the OpenAFS client
+#
+# @param sources
+#   Array CIDR sources that need to be open for the OpenAFS client
 #
 # @example
 #   include openafs::client::firewall
 class openafs::client::firewall (
-  String $dport,
-  String $proto,
-  String $source,
+  Array[String]  $dports,
+  String         $proto,
+  Array[String]  $sources,
 ) {
 
-  firewall { "200 allow OpenAFS via ${proto} from ${source}":
-    proto    => $proto,
-    dport    => $dport,
-    source   => $source,
-    action   => 'accept',
-    provider => 'iptables',
+  $sources.each | $location, $source |
+  {
+    firewall { "200 allow OpenAFS via ${proto} from ${source}":
+      proto    => $proto,
+      dport    => $dports,
+      source   => $source,
+      action   => 'accept',
+    }
   }
 
 }

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -1,37 +1,30 @@
-# @summary A short summary of the purpose of this class
-#
-# A description of what this class does
+# @summary Configure settings common to all OpenAFS services
 #
 # @example
 #   include openafs::common
-class openafs::common (
-  String $cellalias,
-  Hash   $profile_files,
-  String $thiscell,
-) {
+class openafs::common {
 
-  file { '/etc/openafs/ThisCell':
-    ensure  => 'file',
-    content => $thiscell,
-    notify  => Service['openafs-client'],
+  $puppet_file_header = '# This file is managed by Puppet; changes may be overwritten'
+
+  # SPECIFIC FILES FROM LOOKUP
+  $cellalias = lookup('openafs::cellalias')
+  $thiscell = lookup('openafs::thiscell')
+
+  File {
+    owner  => root,
+    group  => root,
+    ensure => file,
+    mode   => '0644',
     require => [
-      Package['openafs-client'],
+      Package['openafs'],
     ],
   }
 
   file { '/etc/openafs/CellAlias':
-    ensure  => 'file',
     content => $cellalias,
-    notify  => Service['openafs-client'],
-    require => [
-      Package['openafs-client'],
-    ],
   }
-
-  $profile_files.each | $filename, $content | {
-    file { $filename:
-      content => $content,
-    }
+  file { '/etc/openafs/ThisCell':
+    content => "${thiscell}\n",
   }
 
 }

--- a/manifests/database_server.pp
+++ b/manifests/database_server.pp
@@ -1,0 +1,22 @@
+# @summary Install and configure OpenAFS database server
+#
+# @example
+#   include openafs::database_server
+class openafs::database_server {
+
+#  include epel
+  include openafs::common
+  include openafs::yumrepo
+  include openafs::database_server::firewall
+  include openafs::database_server::packages
+  include openafs::database_server::service
+  include openafs::server_common
+
+#  Class['epel'] -> 
+  Class['openafs::yumrepo']
+    -> Class['openafs::database_server::packages']
+      -> Class['openafs::common']
+        -> Class['openafs::server_common']
+          -> Class['openafs::database_server::service']
+
+}

--- a/manifests/database_server/firewall.pp
+++ b/manifests/database_server/firewall.pp
@@ -1,0 +1,30 @@
+# @summary Configure the firewall settings for OpenAFS database server
+#
+# @param dports
+#   Array of destination ports that need to be open for the OpenAFS database server
+#
+# @param proto
+#   String of protocol that needs to be open for the OpenAFS database server
+#
+# @param sources
+#   Array CIDR sources that need to be open for the OpenAFS database server
+#
+# @example
+#   include openafs::database_server::firewall
+class openafs::database_server::firewall (
+  Array[String] $dports,
+  String        $proto,
+  Array[String] $sources,
+) {
+
+  $sources.each | $location, $source |
+  {
+    firewall { "200 allow OpenAFS via ${proto} from ${source}":
+      proto    => $proto,
+      dport    => $dports,
+      source   => $source,
+      action   => 'accept',
+    }
+  }
+
+}

--- a/manifests/database_server/packages.pp
+++ b/manifests/database_server/packages.pp
@@ -1,0 +1,21 @@
+# @summary Install packages for OpenAFS database server
+#
+# @param packages
+#   Array of packages that need to be installed for the OpenAFS database server
+#
+# @example
+#   include openafs::database_server::packages
+class openafs::database_server::packages (
+  Array $packages,
+){
+
+#  ensure_packages( $prereq_packages )
+
+  $packages_defaults = {
+    require => [
+      Yumrepo['openafs'],
+    ]
+  }
+  ensure_packages( $packages, $packages_defaults )
+
+}

--- a/manifests/database_server/service.pp
+++ b/manifests/database_server/service.pp
@@ -1,4 +1,4 @@
-# @summary Configure service for OpenAFS client
+# @summary Configure service for OpenAFS database server
 #
 # @param enable
 #   Boolean of whether the default service should be enabled
@@ -10,8 +10,8 @@
 #   String of the name of the default service
 #
 # @example
-#   include openafs::client::service
-class openafs::client::service (
+#   include openafs::database_server::service
+class openafs::database_server::service (
   Boolean $enable,
   String  $ensure,
   String  $service_name,

--- a/manifests/file_server.pp
+++ b/manifests/file_server.pp
@@ -1,0 +1,24 @@
+# @summary Install and configure OpenAFS file server
+#
+# @example
+#   include openafs::file_server
+class openafs::file_server {
+
+#  include epel
+  include openafs::common
+  include openafs::yumrepo
+  include openafs::file_server::firewall
+  include openafs::file_server::packages
+  include openafs::file_server::rebuild
+  include openafs::file_server::service
+  include openafs::server_common
+
+  Class['epel']
+    -> Class['openafs::yumrepo']
+      -> Class['openafs::file_server::packages']
+        -> Class['openafs::common']
+          -> Class['openafs::server_common']
+            -> Class['openafs::file_server::rebuild']
+              -> Class['openafs::file_server::service']
+
+}

--- a/manifests/file_server/firewall.pp
+++ b/manifests/file_server/firewall.pp
@@ -1,0 +1,30 @@
+# @summary Configure the firewall settings for OpenAFS file server
+#
+# @param dports
+#   Array of destination ports that need to be open for the OpenAFS file server
+#
+# @param proto
+#   String of protocol that needs to be open for the OpenAFS file server
+#
+# @param sources
+#   Array CIDR sources that need to be open for the OpenAFS file server
+#
+# @example
+#   include openafs::file_server::firewall
+class openafs::file_server::firewall (
+  Array[String] $dports,
+  String        $proto,
+  Array[String] $sources,
+) {
+
+  $sources.each | $location, $source |
+  {
+    firewall { "200 allow OpenAFS via ${proto} from ${source}":
+      proto    => $proto,
+      dport    => $dports,
+      source   => $source,
+      action   => 'accept',
+    }
+  }
+
+}

--- a/manifests/file_server/packages.pp
+++ b/manifests/file_server/packages.pp
@@ -1,14 +1,14 @@
-# @summary Install packages for OpenAFS client
+# @summary Install packages for OpenAFS file server
 #
 # @param packages
-#   Array of packages that need to be installed for the OpenAFS client
+#   Array of packages that need to be installed for the OpenAFS file server
 #
 # @param prereq_packages
-#   Array of prerequisite packages that need to be installed for the OpenAFS client
+#   Array of prerequisite packages that need to be installed for the OpenAFS file server
 #
 # @example
-#   include openafs::client::packages
-class openafs::client::packages (
+#   include openafs::file_server::packages
+class openafs::file_server::packages (
   Array $packages,
   Array $prereq_packages,
 ){

--- a/manifests/file_server/rebuild.pp
+++ b/manifests/file_server/rebuild.pp
@@ -1,20 +1,21 @@
 # @summary Rebuild the kernel module for OpenAFS when needed
 #
 # @example
-#   include openafs::client::rebuild
-class openafs::client::rebuild {
+#   include openafs::file_server::rebuild
+class openafs::file_server::rebuild {
 
-  # IF AFS FILESYSTEM IS UNAVAILABLE 
+  # IF AFS FILESYSTEM IS UNAVAILABLE
   # INDICATES OpenAFS OR kernel HAVE BEEN UPDATED
   # CAN BE RESOLVED BY REBUILDING VIA REINSTALLING THE dkms-openafs PACKAGE
 
   exec { 'rebuild_afs':
     path    => ['/usr/bin', '/usr/sbin'],
     command => 'yum -y reinstall dkms-openafs',
+## THIS PROBABLY NEED TO CHANGE TO ??
     creates => '/afs/ncsa.uiuc.edu/README',
     onlyif  => 'yum list installed dkms-openafs',
     timeout => '1200',
-    notify  => Service['openafs-client'],
+#    notify  => Service['openafs-client'],
     require => [
       Package['openafs-client'],
     ],

--- a/manifests/file_server/service.pp
+++ b/manifests/file_server/service.pp
@@ -1,4 +1,4 @@
-# @summary Configure service for OpenAFS client
+# @summary Configure service for OpenAFS file server
 #
 # @param enable
 #   Boolean of whether the default service should be enabled
@@ -10,8 +10,8 @@
 #   String of the name of the default service
 #
 # @example
-#   include openafs::client::service
-class openafs::client::service (
+#   include openafs::file_server::service
+class openafs::file_server::service (
   Boolean $enable,
   String  $ensure,
   String  $service_name,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,4 @@
-# @summary A short summary of the purpose of this class
-#
-# A description of what this class does
+# @summary Install and configure OpenAFS packages and services
 #
 # @example
 #   include openafs

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -1,8 +1,0 @@
-# @summary A short summary of the purpose of this class
-#
-# A description of what this class does
-#
-# @example
-#   include openafs::server::database
-class openafs::server::database {
-}

--- a/manifests/server/file.pp
+++ b/manifests/server/file.pp
@@ -1,8 +1,0 @@
-# @summary A short summary of the purpose of this class
-#
-# A description of what this class does
-#
-# @example
-#   include openafs::server::file
-class openafs::server::file {
-}

--- a/manifests/server_common.pp
+++ b/manifests/server_common.pp
@@ -1,0 +1,62 @@
+# @summary Configure common settings to all OpenAFS server types
+#
+# @param files
+#   Hash of common server config files for OpenAFS servers
+#
+# @example
+#   include openafs::server_common
+class openafs::server_common (
+  Hash   $files,
+) {
+
+  File {
+    owner  => root,
+    group  => root,
+    ensure => file,
+    mode   => '0640',
+  }
+
+  ensure_resources('file', $files )
+
+  $puppet_file_header = '# This file is managed by Puppet; changes may be overwritten'
+
+  # SPECIFIC FILES FROM LOOKUP
+  $thiscell = lookup('openafs::thiscell')
+  $cellservdb = lookup('openafs::server::cellservdb')
+  $keyfile_base64 = lookup('openafs::server::keyfile_base64')
+  $keyfileext_base64 = lookup('openafs::server::keyfileext_base64')
+  $krb_conf = lookup('openafs::server::krb_conf')
+  $license = lookup('openafs::server::license')
+  $rxkad_keytab_base64 = lookup('openafs::server::rxkad_keytab_base64')
+  $userlist = lookup('openafs::server::userlist')
+
+  file { '/etc/openafs/server/CellServDB':
+    content => $cellservdb,
+  }
+  file { '/etc/openafs/CellServDB':
+    ensure => 'link',
+    target => '/etc/openafs/server/CellServDB',
+  }
+  file { '/etc/openafs/server/krb.conf':
+    content => "${krb_conf}\n",
+  }
+  file { '/etc/openafs/server/License':
+    content => "${license}\n",
+  }
+  file { '/etc/openafs/server/ThisCell':
+    content => "${thiscell}\n",
+  }
+  file { '/etc/openafs/server/UserList':
+    content => $userlist,
+  }
+  file { '/etc/openafs/server/KeyFile':
+    content => base64('decode', $keyfile_base64),
+  }
+  file { '/etc/openafs/server/KeyFileExt':
+    content => base64('decode', $keyfileext_base64),
+  }
+  file { '/etc/openafs/server/rxkad.keytab':
+    content => base64('decode', rxkad_keytab_base64),
+  }
+
+}

--- a/manifests/yumrepo.pp
+++ b/manifests/yumrepo.pp
@@ -1,6 +1,7 @@
-# @summary A short summary of the purpose of this class
+# @summary Install and configure OpenAFS YUM repository
 #
-# A description of what this class does
+# @param yumrepo
+#   Hash of yumrepo parameters for OpenAFS YUM repository
 #
 # @example
 #   include openafs::yumrepo
@@ -15,7 +16,8 @@ class openafs::yumrepo (
   ensure_resources( 'yumrepo', $yumrepo, $yumrepo_defaults )
 
 #  # FOLLOWING WILL NEED TO CHANGE IF openafs REPO CHANGES ITS GPGKEY
-#  #$gpgpubkeyinstalled="rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-openafs) | cut --characters=11-18 | tr [A-Z] [a-z]`"
+#  #$gpgpubkeyinstalled="rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-openafs) | 
+#     cut --characters=11-18 | tr [A-Z] [a-z]`"
 #  $gpgpubkeyinstalled='rpm -q gpg-pubkey-5124ee19-54c66e4b'
 #  file { '/etc/pki/rpm-gpg/RPM-GPG-KEY-openafs':
 #    ensure => present,

--- a/spec/classes/database_server/firewall_spec.rb
+++ b/spec/classes/database_server/firewall_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'openafs::database_server::firewall' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/classes/database_server/packages_spec.rb
+++ b/spec/classes/database_server/packages_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'openafs::server::file' do
+describe 'openafs::database_server::packages' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }

--- a/spec/classes/database_server/service_spec.rb
+++ b/spec/classes/database_server/service_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'openafs::database_server::service' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/classes/database_server_spec.rb
+++ b/spec/classes/database_server_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'openafs::database_server' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/classes/file_server/firewall_spec.rb
+++ b/spec/classes/file_server/firewall_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'openafs::file_server::firewall' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/classes/file_server/packages_spec.rb
+++ b/spec/classes/file_server/packages_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'openafs::server::database' do
+describe 'openafs::file_server::packages' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }

--- a/spec/classes/file_server/rebuild_spec.rb
+++ b/spec/classes/file_server/rebuild_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'openafs::file_server::rebuild' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/classes/file_server/service_spec.rb
+++ b/spec/classes/file_server/service_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'openafs::file_server::service' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/classes/file_server_spec.rb
+++ b/spec/classes/file_server_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'openafs::file_server' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/classes/server_common_spec.rb
+++ b/spec/classes/server_common_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'openafs::server_common' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end


### PR DESCRIPTION
This puppet module is currently being tested on:
- `asd-test-afsdb1` (as OpenAFS database server)
- `asd-test-afs01` (as OpenAFS client)

The OpenAFS file server has not yet been tested and is not yet ready for production use.


And a bit of background:
- This is needed for https://jira.ncsa.illinois.edu/browse/SVC-1547
- OpenAFS client will allow us to deploy WSI services via `asd-pup` _soon_