### PR TITLE
SVC-1547: Hiera data keys not matching class names

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ To install and configure the **OpenAFS file server**:
 The following parameters need to be set:
 - `openafs::cellalias`: String of your OpenAFS CellAlias content
 - `openafs::thiscell`: String of your OpenAFS ThisCell content
-- `openafs::server::cellservdb`: String of your OpenAFS CellServDB content
-- `openafs::server::keyfile_base64`: String of your base64 encoded KeyFile content
-- `openafs::server::keyfileext_base64`: String of your base64 encoded KeyFileExt content
-- `openafs::server::krb_conf`: String of your OpenAFS krb.conf content (Kerberos realm name)
-- `openafs::server::license`: String of your OpenAFS License content
-- `openafs::server::rxkad_keytab_base64`: String of your base64 encoded rxkad.keytab content
+- `openafs::server_common::cellservdb`: String of your OpenAFS CellServDB content
+- `openafs::server_common::keyfile_base64`: String of your base64 encoded KeyFile content
+- `openafs::server_common::keyfileext_base64`: String of your base64 encoded KeyFileExt content
+- `openafs::server_common::krb_conf`: String of your OpenAFS krb.conf content (Kerberos realm name)
+- `openafs::server_common::license`: String of your OpenAFS License content
+- `openafs::server_common::rxkad_keytab_base64`: String of your base64 encoded rxkad.keytab content
 
 ## Dependencies
 - [puppet/epel](https://forge.puppet.com/puppet/epel)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -453,13 +453,62 @@ include openafs::server_common
 
 The following parameters are available in the `openafs::server_common` class:
 
+* [`cellservdb`](#cellservdb)
 * [`files`](#files)
+* [`keyfile_base64`](#keyfile_base64)
+* [`keyfileext_base64`](#keyfileext_base64)
+* [`krb_conf`](#krb_conf)
+* [`license`](#license)
+* [`rxkad_keytab_base64`](#rxkad_keytab_base64)
+* [`userlist`](#userlist)
+
+##### <a name="cellservdb"></a>`cellservdb`
+
+Data type: `String`
+
+String of CellServDB config file contents for OpenAFS servers
 
 ##### <a name="files"></a>`files`
 
 Data type: `Hash`
 
 Hash of common server config files for OpenAFS servers
+
+##### <a name="keyfile_base64"></a>`keyfile_base64`
+
+Data type: `String`
+
+String of base64 encoding of the KeyFile file contents for OpenAFS servers
+
+##### <a name="keyfileext_base64"></a>`keyfileext_base64`
+
+Data type: `String`
+
+String of base64 encoding of the KeyFileExt file contents for OpenAFS servers
+
+##### <a name="krb_conf"></a>`krb_conf`
+
+Data type: `String`
+
+String of krb.conf config file contents for OpenAFS servers
+
+##### <a name="license"></a>`license`
+
+Data type: `String`
+
+String of License file contents for OpenAFS servers
+
+##### <a name="rxkad_keytab_base64"></a>`rxkad_keytab_base64`
+
+Data type: `String`
+
+String of base64 encoding of the rxkad.keytab file contents for OpenAFS servers
+
+##### <a name="userlist"></a>`userlist`
+
+Data type: `String`
+
+String of UserList file contents for OpenAFS servers
 
 ### <a name="openafsyumrepo"></a>`openafs::yumrepo`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -14,13 +14,13 @@ openafs::client::firewall::sources:
 openafs::cellalias: |
   changeme.local changeme
 openafs::thiscell: "changeme.local"
-openafs::server::cellservdb: {}
-openafs::server::keyfile_base64: {}
-openafs::server::keyfileext_base64: {}
-openafs::server::krb_conf: "CHANGEME.LOCAL"
-openafs::server::license: {}
-openafs::server::rxkad_keytab_base64: {}
-openafs::server::userlist: |
+openafs::server_common::cellservdb: {}
+openafs::server_common::keyfile_base64: {}
+openafs::server_common::keyfileext_base64: {}
+openafs::server_common::krb_conf: "CHANGEME.LOCAL"
+openafs::server_common::license: {}
+openafs::server_common::rxkad_keytab_base64: {}
+openafs::server_common::userlist: |
   admin
   backup
   vdvadmin

--- a/manifests/client/firewall.pp
+++ b/manifests/client/firewall.pp
@@ -20,10 +20,10 @@ class openafs::client::firewall (
   $sources.each | $location, $source |
   {
     firewall { "200 allow OpenAFS via ${proto} from ${source}":
-      proto    => $proto,
-      dport    => $dports,
-      source   => $source,
-      action   => 'accept',
+      proto  => $proto,
+      dport  => $dports,
+      source => $source,
+      action => 'accept',
     }
   }
 

--- a/manifests/database_server/firewall.pp
+++ b/manifests/database_server/firewall.pp
@@ -20,10 +20,10 @@ class openafs::database_server::firewall (
   $sources.each | $location, $source |
   {
     firewall { "200 allow OpenAFS via ${proto} from ${source}":
-      proto    => $proto,
-      dport    => $dports,
-      source   => $source,
-      action   => 'accept',
+      proto  => $proto,
+      dport  => $dports,
+      source => $source,
+      action => 'accept',
     }
   }
 

--- a/manifests/file_server/firewall.pp
+++ b/manifests/file_server/firewall.pp
@@ -20,10 +20,10 @@ class openafs::file_server::firewall (
   $sources.each | $location, $source |
   {
     firewall { "200 allow OpenAFS via ${proto} from ${source}":
-      proto    => $proto,
-      dport    => $dports,
-      source   => $source,
-      action   => 'accept',
+      proto  => $proto,
+      dport  => $dports,
+      source => $source,
+      action => 'accept',
     }
   }
 

--- a/manifests/server_common.pp
+++ b/manifests/server_common.pp
@@ -1,12 +1,40 @@
 # @summary Configure common settings to all OpenAFS server types
 #
+# @param cellservdb
+#   String of CellServDB config file contents for OpenAFS servers
+#
 # @param files
 #   Hash of common server config files for OpenAFS servers
+#
+# @param keyfile_base64
+#   String of base64 encoding of the KeyFile file contents for OpenAFS servers
+#
+# @param keyfileext_base64
+#   String of base64 encoding of the KeyFileExt file contents for OpenAFS servers
+#
+# @param krb_conf
+#   String of krb.conf config file contents for OpenAFS servers
+#
+# @param license
+#   String of License file contents for OpenAFS servers
+#
+# @param rxkad_keytab_base64
+#   String of base64 encoding of the rxkad.keytab file contents for OpenAFS servers
+#
+# @param userlist
+#   String of UserList file contents for OpenAFS servers
 #
 # @example
 #   include openafs::server_common
 class openafs::server_common (
+  String $cellservdb,
   Hash   $files,
+  String $keyfile_base64,
+  String $keyfileext_base64,
+  String $krb_conf,
+  String $license,
+  String $rxkad_keytab_base64,
+  String $userlist,
 ) {
 
   File {
@@ -22,13 +50,10 @@ class openafs::server_common (
 
   # SPECIFIC FILES FROM LOOKUP
   $thiscell = lookup('openafs::thiscell')
-  $cellservdb = lookup('openafs::server::cellservdb')
-  $keyfile = Sensitive( base64('decode', lookup('openafs::server::keyfile_base64') ) )
-  $keyfileext = Sensitive( base64('decode', lookup('openafs::server::keyfileext_base64') ) )
-  $krb_conf = lookup('openafs::server::krb_conf')
-  $license = Sensitive( lookup('openafs::server::license') )
-  $rxkad_keytab = Sensitive( base64('decode', lookup('openafs::server::rxkad_keytab_base64') ) )
-  $userlist = lookup('openafs::server::userlist')
+  # DECODE BASE64 PARAMETERS
+  $keyfile = Sensitive( base64('decode', $keyfile_base64 ) )
+  $keyfileext = Sensitive( base64('decode', $keyfileext_base64 ) )
+  $rxkad_keytab = Sensitive( base64('decode', $rxkad_keytab_base64 ) )
 
   file { '/etc/openafs/server/CellServDB':
     content => $cellservdb,
@@ -41,7 +66,7 @@ class openafs::server_common (
     content => "${krb_conf}\n",
   }
   file { '/etc/openafs/server/License':
-    content => $license,
+    content => Sensitive($license),
   }
   file { '/etc/openafs/server/ThisCell':
     content => "${thiscell}\n",


### PR DESCRIPTION
See GitHub issue: https://github.com/ncsa/puppet-openafs/issues/2

Move lookup of openafs::server_common parameters to normal class parameters