### PR TITLE
SECURITY-1313: Security vetting review of OpenAFS DB Server

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -22,7 +22,6 @@ openafs::server_common::license: {}
 openafs::server_common::rxkad_keytab_base64: {}
 openafs::server_common::userlist: |
   admin
-  backup
   vdvadmin
   adminl
 

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -6,6 +6,31 @@ class openafs::common {
 
   $puppet_file_header = '# This file is managed by Puppet; changes may be overwritten'
 
+# WERE TESTING FORCING UPDATES TO /etc/hosts - DO NOT THINK NEEDED
+#  file_line { 'hosts_localhost_ipv6':
+#    ensure            => absent,
+#    path              => '/etc/hosts',
+#    #line              => '::1 localhost',
+#    match             => '::1.*localhost',
+#    match_for_absence => true,
+#  }
+#  host { $facts['fqdn']:
+#    ensure       => 'present',
+#    host_aliases => [
+#      $facts['hostname'],
+#    ],
+#    ip           => $facts['ipaddress'],
+#  }
+#  host { 'localhost':
+#    ensure       => 'present',
+#    host_aliases => [
+#      'localhost.localdomain',
+#      'localhost4',
+#      'localhost4.localdomain4',
+#    ],
+#    ip           => '127.0.0.1',
+#  }
+
   # SPECIFIC FILES FROM LOOKUP
   $cellalias = lookup('openafs::cellalias')
   $thiscell = lookup('openafs::thiscell')

--- a/manifests/server_common.pp
+++ b/manifests/server_common.pp
@@ -57,7 +57,7 @@ class openafs::server_common (
 
   file { '/etc/openafs/server/CellServDB':
     content => $cellservdb,
-    mode   => '0644',
+    mode    => '0644',
   }
   file { '/etc/openafs/CellServDB':
     ensure => 'link',
@@ -83,6 +83,10 @@ class openafs::server_common (
   }
   file { '/etc/openafs/server/rxkad.keytab':
     content => $rxkad_keytab,
+  }
+  file { '/var/openafs/NetInfo':
+    content => $facts['ipaddress'],
+    mode    => '0644',
   }
 
 }


### PR DESCRIPTION
Add NetInfo file for openafs servers - fix #8 
Remove 'backup' user from /etc/openafs/server/UserList

See https://jira.ncsa.illinois.edu/browse/SECURITY-1313
This is being tested on `asd-test-afsdb1`.